### PR TITLE
Add cpu steal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased]
+## [Unreleased]
+### Added
+- metric-vmstat: added CPU steal metric
 
 ## [0.0.3] - 2015-07-14
 ### Changed

--- a/bin/metrics-vmstat.rb
+++ b/bin/metrics-vmstat.rb
@@ -77,7 +77,8 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
         user: result[12],
         system: result[13],
         idle: result[14],
-        waiting: result[15]
+        waiting: result[15],
+        steal: result[16]
       }
     }
     metrics.each do |parent, children|


### PR DESCRIPTION
## Pull Request Checklist

Carried this commit over from #3. I'd like to cut a new release with this change, as well as removing Ruby 1.9 support, so we'll need to increment the major version.

Closes #2 
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

Adds metric for CPU steal to output of metric-vmstat
#### Known Compatablity Issues

None
