### PR TITLE
Remove Ruby 1.9.3 support; add Ruby 2.3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
 notifications:
   email:
     recipients:
@@ -26,8 +26,8 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
     repo: sensu-plugins/sensu-plugins-vmstats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - metric-vmstat: added CPU steal metric
 
+### Changed
+- Loosen dependency on sensu-plugin from `= 1.2.0` to `~> 1.2`
+- Update Rubocop to 0.40, apply auto-correct
+
+### Removed
+- Remove Ruby 1.9.3 support; add Ruby 2.3.0 support in test matrix.
+
 ## [0.0.3] - 2015-07-14
 ### Changed
 - updated sensu-plugin gem to 1.2.0

--- a/sensu-plugins-vmstats.gemspec
+++ b/sensu-plugins-vmstats.gemspec
@@ -2,12 +2,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
-if RUBY_VERSION < '2.0.0'
-  require 'sensu-plugins-vmstats'
-else
-  require_relative 'lib/sensu-plugins-vmstats'
-end
+require_relative 'lib/sensu-plugins-vmstats'
 
 Gem::Specification.new do |s|
   s.authors                = ['Sensu-Plugins and contributors']
@@ -30,7 +25,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
 
   s.summary                = 'Sensu plugins for working with vmstats'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [ ] Update README with any necessary configuration snippets
- [ ] Binstubs are created if needed
- [x] RuboCop passes
- [x] Existing tests pass 
#### Purpose

This PR removes Ruby 1.9.3 support, and adds support for testing under Ruby 2.3.0, per the Sensu Plugins policy: 

> Ruby 1.9.3 (EOL): Linting is not done against it, and 1.9.3 will be supported where possible till Feb 2016 which is one year after EOL and 2 years after EOL was announced.
#### Known Compatibility Issues

Adds incompatibility with Ruby version < 2.0.0
