### PR TITLE
Fix a typo in the file path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Sensu assets packaged from this repository are built against the Sensu Ruby 
 ## Functionality
 
 ## Files
- * bin/metrics-vmstats.rb
+ * bin/metrics-vmstat.rb
 
 ## Usage
 


### PR DESCRIPTION
The README was referencing `bin/metrics-vmstats.rb` instead of `bin/metrics-vmstat.rb`